### PR TITLE
quality/test-recursively: Don't try to match 3rd party libs

### DIFF
--- a/quality/test-recursively
+++ b/quality/test-recursively
@@ -3,14 +3,9 @@
 use warnings;
 use strict;
 
-my $third_party_failed_count = 0;
 my $failed_count = 0;
 my $run_count =0;
 my $target = shift;
-
-# Third party libraries may fail our test suite. Since we don't have commit,
-# we complain but don't fail the whole run for that
-my @THIRD_PARTY_LIBRARIES = qw/Kaleidoscope-Hardware-Shortcut/;
 
 my $pwd = `pwd`;
 chomp($pwd);
@@ -37,11 +32,7 @@ for my $dir (@files) {
             print STDERR "\n$contents\n";
         }
         unlink(".build-log");
-	if (! grep $dir, @THIRD_PARTY_LIBRARIES ) {
-        	$failed_count += $result;
-	} else {
-		$third_party_failed_count += $result;
-	}
+        $failed_count += $result;
         $run_count++;
     } else {
         print " skip\n";
@@ -50,6 +41,5 @@ for my $dir (@files) {
 
 print STDERR "Ran tests:          $run_count\n";
 print STDERR "Total failures:     $failed_count\n";
-print STDERR "3rd party failures: $third_party_failed_count\n";
 exit($failed_count);
 #make -pRrq |grep -q '^travis-test:$'


### PR DESCRIPTION
With our new setup, having vendor-specific bundles, there are no third part libraries. As such, we do not need to ignore errors from them, and that code can be removed.

As it turns out, that code did not work too well, it made all failures appear under the third party counter.

With the removal, that's no longer the case, and this fixes keyboardio/Kaleidoscope-Bundle-Keyboardio#4.
