### PR TITLE
New CLI build system

### DIFF
--- a/makefiles/arduino.mk
+++ b/makefiles/arduino.mk
@@ -1,0 +1,92 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+ARDUINO_PATH                 ?= /usr/local/arduino
+ARDUINO_LOCAL_LIB_PATH       ?= ${HOME}/Arduino
+ARDUINO_TOOLS_PATH           ?= ${ARDUINO_PATH}/hardware/tools
+ARDUINO_TOOLS_PARAM          ?= -tools ${ARDUINO_TOOLS_PATH}
+ARDUINO_PACKAGE_PATH         ?= ${HOME}/.arduino15/packages
+ARDUINO_PACKAGES             := $(shell test -d ${ARDUINO_PACKAGE_PATH} && echo "-hardware \"${ARDUINO_PACKAGE_PATH}\"")
+ARDUINO_AVR_GCC_PREFIX_PARAM ?= -prefs "runtime.tools.avr-gcc.path=${AVR_GCC_PREFIX}"
+
+ARDUINO_BUILDER              ?= ${ARDUINO_PATH}/arduino-builder
+ARDUINO_IDE_VERSION          ?= 10607
+
+BOARD_HARDWARE_PATH          ?= $(abspath $(dir $(lastword ${MAKEFILE_LIST}))../../../../../)
+FQBN                         ?= keyboardio:avr:${BOARD}
+
+ifeq (${OS},FreeBSD)
+AVR_NM                       ?= /usr/local/bin/avr-nm
+AVR_OBJDUMP                  ?= /usr/local/bin/avr-objdump
+AVR_SIZE                     ?= /usr/local/bin/avr-size
+else
+AVR_NM                       ?= ${ARDUINO_TOOLS_PATH}/avr/bin/avr-nm
+AVR_OBJDUMP                  ?= ${ARDUINO_TOOLS_PATH}/avr/bin/avr-objdump
+AVR_SIZE                     ?= ${ARDUINO_TOOLS_PATH}/avr/bin/avr-size
+endif
+
+AVR_SIZE_FLAGS               ?= -C --mcu=${MCU}
+
+${DESTDIR}${OUTPUT_DIR}:
+	install -d $@
+
+compile ${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.hex ${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.elf: ${DESTDIR}${OUTPUT_DIR}
+ifeq (${V},)
+	@echo "Building ${OUTPUT_DIR}/${SKETCH} (${SKETCH_VERSION})"
+endif
+	${ARDUINO_BUILDER} \
+		-compile \
+		${ARDUINO_PACKAGES} \
+		-hardware "${ARDUINO_PATH}/hardware" \
+		-hardware "${BOARD_HARDWARE_PATH}" \
+		${ARDUINO_TOOLS_PARAM} \
+		-tools "${ARDUINO_PATH}/tools-builder" \
+		-fqbn "${FQBN}" \
+		-libraries "." \
+		-build-path "${BUILD_PATH}" \
+		-ide-version "${ARDUINO_IDE_VERSION}" \
+		-prefs "compiler.cpp.extra_flags=-std=c++11 -Woverloaded-virtual -Wno-unused-parameter -Wno-unused-variable -Wno-ignored-qualifiers ${ARDUINO_CFLAGS} ${LOCAL_CFLAGS}" \
+		-warnings all \
+		${ARDUINO_VERBOSE} \
+		${ARDUINO_AVR_GCC_PREFIX_PARAM} \
+		${ARDUINO_BUILDER_ARGS} \
+		${SKETCH_SOURCEDIR}/${SKETCH}.ino  \
+	| sed -e "/Maximum is [0-9]* bytes/d"
+
+	cp "${BUILD_PATH}/${SKETCH}.ino.hex" "${DESTDIR}${OUTPUT_DIR}/${SKETCH}-${SKETCH_VERSION}.hex"
+	cp "${BUILD_PATH}/${SKETCH}.ino.elf" "${DESTDIR}${OUTPUT_DIR}/${SKETCH}-${SKETCH_VERSION}.elf"
+	cp "${BUILD_PATH}/${SKETCH}.ino.hex" "${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.hex"
+	cp "${BUILD_PATH}/${SKETCH}.ino.elf" "${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.elf"
+	rm -rf "${BUILD_PATH}"
+
+clean:
+	rm -rf -- "${DESTDIR}${OUTPUT_DIR}"
+
+size: ${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.elf
+size: PROG_SIZE = $(shell ${AVR_SIZE} ${AVR_SIZE_FLAGS} $< | sed -ne "s#Program: *\([0-9]*\).*#\1#p" | awk '{printf "%5s", $$1}')
+size: DATA_SIZE = $(shell ${AVR_SIZE} ${AVR_SIZE_FLAGS} $< | sed -ne "s#Data: *\([0-9]*\).*#\1#p" | awk '{printf "%5s", $$1}')
+size: PROG_SIZE_PERCENT = $(shell echo ${PROG_SIZE} ${PROG_SIZE_MAX} | awk "{ printf \"%02.01f\", \$$1 / \$$2 * 100 }")
+size: DATA_SIZE_PERCENT = $(shell echo ${DATA_SIZE} ${DATA_SIZE_MAX} | awk "{ printf \"%02.01f\", \$$1 / \$$2 * 100 }")
+size:
+	@echo " - Program: ${PROG_SIZE} bytes (${PROG_SIZE_PERCENT}%)"
+	@echo " - Data:    ${DATA_SIZE} bytes (${DATA_SIZE_PERCENT}%)"
+
+size-map: ${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.elf
+	"${AVR_NM}" --size-sort -C -r -l -t decimal "$<"
+
+disassemble decompile: ${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.elf
+	"${AVR_OBJDUMP}" -C -d "$<"
+
+build: compile size
+
+.PHONY: compile clean build size size-map disassemble decompile

--- a/makefiles/boards/atreus.mk
+++ b/makefiles/boards/atreus.mk
@@ -1,0 +1,63 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+VID            := 0x1209
+PID            := 0xa1e5
+BOOTLOADER_VID := ${VID}
+BOOTLOADER_PID := ${PID}
+MCU            := atmega32u4
+PINOUT         ?= post-2016
+CPU            ?= teensy
+
+DATA_SIZE_MAX  := 2560
+
+include ${MAKEFILE_RULES_DIR}/boards/common.mk
+include ${MAKEFILE_RULES_DIR}/flasher/avrdude.mk
+include ${MAKEFILE_RULES_DIR}/flasher/teensy-cli.mk
+
+ifeq (${PINOUT},post-2016)
+ARDUINO_CFLAGS  = -DKALEIDOSCOPE_HARDWARE_ATREUS_PINOUT_ASTAR=1
+else
+ifeq (${PINOUT},pre-2016)
+ARDUINO_CFLAGS  = -DKALEIDOSCOPE_HARDWARE_ATREUS_PINOUT_ASTAR_DOWN=1
+else
+ifeq (${PINOUT},legacy-teensy)
+ARDUINO_CFLAGS  = -DKALEIDOSCOPE_HARDWARE_ATREUS_PINOUT_LEGACY_TEENSY2=1
+else
+$(error "Unknown PINOUT: ${PINOUT}.")
+endif
+endif
+endif
+
+ifeq (${CPU},teensy)
+PROG_SIZE_MAX  := 32256
+else
+PROG_SIZE_MAX  := 28672
+endif
+
+flash/prepare:
+	@echo "To update your keyboard's firmware, press the reset button on the back of"
+	@echo "your keyboard, and then press 'Enter'."
+	@echo ""
+
+	@read a
+
+flash: flash/${CPU}
+flash/astar: flash/avrdude
+
+supported-device-list:
+	@echo 'BOARD=atreus'
+	@echo ' - CPU: "astar" or "teensy"'
+	@echo ' - PINOUT: "legacy-teensy", "pre-2016", or "post-2016"'
+
+.PHONY: flash flash/prepare supported-device-list

--- a/makefiles/boards/common.mk
+++ b/makefiles/boards/common.mk
@@ -1,0 +1,32 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+ifeq (${OS},Linux)
+RESET_COMMAND = stty -F ${DEVICE_PORT} 1200 hupcl
+PORT_FINDER   = ${TOOLS_DIR}/find-device-port-linux-udev
+else
+ifeq (${OS},Darwin)
+RESET_COMMAND = stty -f ${DEVICE_PORT} 1200
+PORT_FINDER   = ${TOOLS_DIR}/find-device-port-macos
+else
+ifeq (${OS},FreeBSD)
+RESET_COMMAND = stty -f ${DEVICE_PORT} 1200
+PORT_FINDER   = ${TOOLS_DIR}/find-device-port-freebsd
+else
+$(error "Unsupported platform: \`${OS}\`, please file an issue.")
+endif
+endif
+endif
+
+DEVICE_PORT            ?= $(shell perl ${PORT_FINDER} ${VID} ${PID})
+DEVICE_PORT_BOOTLOADER ?= $(shell perl ${PORT_FINDER} ${BOOTLOADER_VID} ${BOOTLOADER_PID})

--- a/makefiles/boards/ergodox.mk
+++ b/makefiles/boards/ergodox.mk
@@ -1,0 +1,38 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+VID            := 0xfeed
+PID            := 0x1307
+BOOTLOADER_VID := ${VID}
+BOOTLOADER_PID := ${PID}
+MCU            := atmega32u4
+
+PROG_SIZE_MAX  := 32256
+DATA_SIZE_MAX  := 2560
+
+include ${MAKEFILE_RULES_DIR}/boards/common.mk
+include ${MAKEFILE_RULES_DIR}/flasher/teensy-cli.mk
+
+flash/prepare:
+	@echo "To update your keyboard's firmware, press the reset button on your keyboard,"
+	@echo "and then press 'Enter'."
+	@echo ""
+
+	@read a
+
+flash: flash/teensy
+
+supported-device-list:
+	@echo 'BOARD=ergodox'
+
+.PHONY: flash flash/prepare supported-device-list

--- a/makefiles/boards/model01.mk
+++ b/makefiles/boards/model01.mk
@@ -1,0 +1,53 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+VID            := 0x1209
+PID            := 0x2301
+BOOTLOADER_VID := 0x1209
+BOOTLOADER_PID := 0x2300
+MCU            := atmega32u4
+
+PROG_SIZE_MAX  := 28672
+DATA_SIZE_MAX  := 2560
+
+include ${MAKEFILE_RULES_DIR}/boards/common.mk
+include ${MAKEFILE_RULES_DIR}/flasher/avrdude.mk
+
+flash/prepare:
+	@echo "To update your keyboard's firmware, hold down the 'Prog' key on your keyboard,"
+	@echo "and then press 'Enter'."
+	@echo ""
+	@echo "When the 'Prog' key glows red, you can release it."
+	@echo ""
+
+	@read a
+
+flash/reset:
+	${RESET_COMMAND}
+	sleep 3
+
+flash/avrdude: flash/check
+
+flash/check: flash/reset
+	@if [ -z "${DEVICE_PORT_BOOTLOADER}" ]; then \
+		echo "Unable to detect a keyboard in bootloader mode. You may need to hold the 'Prog' key or hit a reset button."; \
+		exit 1; \
+	fi
+
+flash: ${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.hex
+	${MAKE} flash/avrdude
+
+supported-device-list:
+	@echo 'BOARD=model01'
+
+.PHONY: flash flash/prepare flash/reset flash/check supported-device-list

--- a/makefiles/boards/planck.mk
+++ b/makefiles/boards/planck.mk
@@ -1,0 +1,38 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+VID            := 0x1209
+PID            := 0x2303
+BOOTLOADER_VID := ${VID}
+BOOTLOADER_PID := ${PID}
+MCU            := atmega32u4
+
+PROG_SIZE_MAX  := 28672
+DATA_SIZE_MAX  := 2560
+
+include ${MAKEFILE_RULES_DIR}/boards/common.mk
+include ${MAKEFILE_RULES_DIR}/flasher/dfu-programmer.mk
+
+flash/prepare:
+	@echo "To update your keyboard's firmware, press the reset button on your keyboard,"
+	@echo "and then press 'Enter'."
+	@echo ""
+
+	@read a
+
+flash: flash/dfu-programmer
+
+supported-device-list:
+	@echo 'BOARD=planck'
+
+.PHONY: flash flash/prepare supported-device-list

--- a/makefiles/boards/splitography.mk
+++ b/makefiles/boards/splitography.mk
@@ -1,0 +1,38 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+VID            := 0xfeed
+PID            := 0x6060
+BOOTLOADER_VID := ${VID}
+BOOTLOADER_PID := ${PID}
+MCU            := atmega32u4
+
+PROG_SIZE_MAX  := 28672
+DATA_SIZE_MAX  := 2560
+
+include ${MAKEFILE_RULES_DIR}/boards/common.mk
+include ${MAKEFILE_RULES_DIR}/flasher/dfu-programmer.mk
+
+flash/prepare:
+	@echo "To update your keyboard's firmware, press the reset button on the left half,"
+	@echo "and then press 'Enter'."
+	@echo ""
+
+	@read a
+
+flash: flash/dfu-programmer
+
+supported-device-list:
+	@echo 'BOARD=splitography'
+
+.PHONY: flash flash/prepare supported-device-list

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -1,0 +1,25 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+SKETCH_SOURCEDIR    ?= .
+SKETCH              ?= $(notdir ${CURDIR})
+SKETCH_DATE         := $(shell date +%Y%m%d%H%M%S)
+SKETCH_VERSION      ?= ${SKETCH_DATE}
+
+OS                  := $(shell uname -s)
+
+TOOLS_DIR           := ${MAKEFILE_RULES_DIR}/../tools
+
+DESTDIR             ?= ./
+OUTPUT_DIR          ?= output
+BUILD_PATH          := $(shell mktemp -d 2>/dev/null || mktemp -d -t 'build')

--- a/makefiles/flasher/avrdude.mk
+++ b/makefiles/flasher/avrdude.mk
@@ -1,0 +1,33 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+ifeq (${OS},FreeBSD)
+AVRDUDE      ?= /usr/local/bin/avrdude
+AVRDUDE_CONF ?= /usr/local/etc/avrdude.conf
+else
+AVRDUDE      ?= ${ARDUINO_TOOLS_PATH}/avr/bin/avrdude
+AVRDUDE_CONF ?= ${ARDUINO_TOOLS_PATH}/avr/etc/avrdude.conf
+endif
+
+flash/avrdude: ${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.hex flash/prepare
+	${AVRDUDE} \
+		-q -q \
+		-C "${AVRDUDE_CONF}" \
+		-p"${MCU}" \
+		-cavr109 \
+		-D \
+		-P "${DEVICE_PORT_BOOTLOADER}" \
+		-b57600 \
+		"-Uflash:w:$<:i"
+
+.PHONY: flash/avrdude

--- a/makefiles/flasher/dfu-programmer.mk
+++ b/makefiles/flasher/dfu-programmer.mk
@@ -1,0 +1,21 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+DFU_PROGRAMMER ?= dfu-programmer
+
+flash/dfu-programmer: ${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.hex flash/prepare
+	${DFU_PROGRAMMER} ${MCU} erase
+	${DFU_PROGRAMMER} ${MCU} flash "$<"
+	${DFU_PROGRAMMER} ${MCU} start
+
+.PHONY: flash/dfu-programmer

--- a/makefiles/flasher/teensy-cli.mk
+++ b/makefiles/flasher/teensy-cli.mk
@@ -1,0 +1,19 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+TEENSY_CLI ?= teensy_loader_cli
+
+flash/teensy: ${DESTDIR}${OUTPUT_DIR}/${SKETCH}-latest.hex flash/prepare
+	${TEENSY_CLI} --mcu "${MCU}" -w "$<"
+
+.PHONY: flash/teensy

--- a/makefiles/sketch.mk
+++ b/makefiles/sketch.mk
@@ -1,0 +1,35 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+## Note: This file is meant to be included by individual sketches/examples. It
+## only builds a single sketch.
+
+ifeq (${BOARD},)
+$(error Please set $${BOARD}, otherwise the sketch cannot be compiled.)
+endif
+
+MAKEFILE_RULES_DIR := $(dir $(lastword ${MAKEFILE_LIST}))
+
+OUTPUT_DIR         ?= output/$(shell              \
+	echo "${CURDIR}" | grep -q ".*/examples/"    && \
+	echo "${CURDIR}" | sed -e "s,.*/examples/,," || \
+	echo \${SKETCH}                                 \
+)
+
+include ${MAKEFILE_RULES_DIR}/verbose.mk
+include ${MAKEFILE_RULES_DIR}/common.mk
+include ${MAKEFILE_RULES_DIR}/arduino.mk
+include ${MAKEFILE_RULES_DIR}/tests.mk
+include ${MAKEFILE_RULES_DIR}/boards/${BOARD}.mk
+
+.DEFAULT_GOAL := build

--- a/makefiles/tests.mk
+++ b/makefiles/tests.mk
@@ -1,0 +1,30 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+PLUGIN_TEST_SUPPORT_DIR     ?= ${MAKEFILE_RULES_DIR}/..
+PLUGIN_TEST_BIN_DIR         ?= $(PLUGIN_TEST_SUPPORT_DIR)/../toolchain/$(shell gcc --print-multiarch)/bin
+
+astyle:
+	PATH="$(PLUGIN_TEST_BIN_DIR):$(PATH)" $(PLUGIN_TEST_SUPPORT_DIR)/quality/run-astyle
+check-astyle: astyle
+	PATH="$(PLUGIN_TEST_BIN_DIR):$(PATH)" $(PLUGIN_TEST_SUPPORT_DIR)/quality/astyle-check
+
+.PHONY: astyle check-astyle
+
+cpplint-noisy:
+	-$(PLUGIN_TEST_SUPPORT_DIR)/quality/cpplint.py  --filter=-legal/copyright,-build/include,-readability/namespace,-whitespace/line_length,-runtime/references  --recursive --extensions=cpp,h,ino --exclude=$(BOARD_HARDWARE_PATH) --exclude=$(TRAVIS_ARDUINO) src examples
+
+cpplint:
+	$(PLUGIN_TEST_SUPPORT_DIR)/quality/cpplint.py  --quiet --filter=-whitespace,-legal/copyright,-build/include,-readability/namespace,-runtime/references  --recursive --extensions=cpp,h,ino src examples
+
+.PHONY: cpplint cpplint-noisy

--- a/makefiles/travis.mk
+++ b/makefiles/travis.mk
@@ -1,0 +1,75 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+## Note: This file is meant to be included by Kaleidoscope, or a bundle, not by
+## individual examples or sketches!
+
+MAKEFILE_RULES_DIR          := $(dir $(lastword ${MAKEFILE_LIST}))
+BOARD_HARDWARE_PATH         ?= $(abspath $(dir $(lastword ${MAKEFILE_LIST}))../../../)
+
+include ${MAKEFILE_RULES_DIR}/verbose.mk
+
+TRAVIS_ARDUINO              ?= arduino-1.8.2
+TRAVIS_ARDUINO_FILE         ?= ${TRAVIS_ARDUINO}-linux64.tar.xz
+TRAVIS_ARDUINO_PATH         ?= ${CURDIR}/${TRAVIS_ARDUINO}
+TRAVIS_ARDUINO_DOWNLOAD_URL ?= http://downloads.arduino.cc/${TRAVIS_ARDUINO_FILE}
+
+.DEFAULT_GOAL := build
+
+travis-test: travis-build travis-check-astyle
+test: build check-astyle cpplint-noisy
+
+.PHONY: travis-test travis-smoke-examples travis-check-astyle
+.PHONY: test smoke-examples cpplint cpplint-noisy
+.PHONY: travis-install-arduino
+
+%:
+	for e in $(shell echo ${EXAMPLES} | sort); do \
+		${MAKE} -C $$e $@; \
+	done
+
+## NOTE: HERE BE DRAGONS, DO NOT CLEAN THIS UP!
+# When building outside of the bundle, we want to use the current library, not
+# whatever version is in the bundle at the time. To do so, we must tell
+# arduino-builder about the library, because the current directory is not
+# considered by default.
+#
+# Now, we can't use -libraries ., because arduino-builder will search for a
+# directory named like the library, and we don't have that. We are already in
+# the library directory at this point.
+#
+# So, we need a library outside of the current dir. We could use .., but we want
+# to be safe, to only have the current library there. For this reason, the
+# travis-build target will create a current-libraries directory one level up,
+# symlink the current directory there, under the library name, and add
+# -libraries $(pwd)/../current-libraries to the arduino-builder arguments.
+#
+# All of this makes the builder consider the current library the best to use.
+travis-build: travis-install-arduino
+travis-%:
+	install -d ../current-libraries
+	rm ../current-libraries/* && ln -s $$(pwd) ../current-libraries/
+	ARDUINO_PATH="$(TRAVIS_ARDUINO_PATH)" BOARD_HARDWARE_PATH="$(BOARD_HARDWARE_PATH)" ARDUINO_BUILDER_ARGS="-libraries $$(pwd)/../current-libraries" ${MAKE} $*
+	rm -rf ../current-libraries
+
+travis-install-arduino:
+	@if [ ! -d "$(TRAVIS_ARDUINO_PATH)" ]; then \
+		echo "Installing Arduino..."; \
+		wget -O "$(TRAVIS_ARDUINO_FILE)" -c $(TRAVIS_ARDUINO_DOWNLOAD_URL); \
+		tar xf $(TRAVIS_ARDUINO_FILE); \
+	fi
+
+travis-smoke-examples:
+	${MAKE} travis-build
+
+.PHONY: travis-install-arduino travis-%

--- a/makefiles/verbose.mk
+++ b/makefiles/verbose.mk
@@ -1,0 +1,20 @@
+# Copyright (C) 2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+ifeq (${V},)
+	MAKEFLAGS       = -s
+else
+ifeq (${V},2)
+	ARDUINO_VERBOSE = -verbose
+endif
+endif

--- a/tools/find-device-port-freebsd
+++ b/tools/find-device-port-freebsd
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+
+use warnings;
+use strict;
+
+#
+# Scan all USB devices to find the Model 01's modem device number.
+#
+my @output = qx(/usr/sbin/usbconfig show_ifdrv);
+my $serial_port_number;
+
+foreach my $line (@output) {
+  chomp $line;
+
+  next unless $line =~ m/umodem(\d+):.*Keyboardio Model 01/;
+  $serial_port_number = $1;
+}
+
+die "Can't find Model 01" unless defined($serial_port_number);
+
+my $serial_port_name = "/dev/cuaU$serial_port_number";
+die "Missing serial port at $serial_port_name" unless -e $serial_port_name;
+print "$serial_port_name\n";
+exit 0;

--- a/tools/find-device-port-linux-udev
+++ b/tools/find-device-port-linux-udev
@@ -1,0 +1,93 @@
+#!/usr/bin/env perl
+# find-device-port-linux-udev - Kaleidoscope helper tool
+# Copyright (C) 2017-2018  Keyboard.io, Inc.
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+use warnings;
+use strict;
+
+use FindBin qw{$Bin};
+
+die "Usage: $0 VID PID [-v]\n" unless @ARGV >= 2;
+
+my $vid    = shift @ARGV;
+my $pid    = shift @ARGV;
+my $verbose = shift @ARGV if (@ARGV);
+my $prefix = '/dev/serial/by-id/';
+my @paths  = `ls $prefix`;
+my %devices;
+my @log;
+
+sub debug {
+   if ($verbose) {
+	 print STDERR @_;
+   } else {
+	push @log, @_;
+   }
+}
+
+sub print_warning {
+    print STDERR @_;
+}
+
+
+debug "Looking for USB device with vid=$vid and pid=$pid\n";
+
+for my $path (@paths) {
+    chomp($path);
+    debug "Examining $path\n";
+    debug "  not symlink\n" unless -l $prefix . $path;
+    next unless -l $prefix . $path;
+    my @data = `udevadm info -q property --name=${prefix}${path}`;
+    for my $line (@data) {
+        chomp($line);
+        my ( $key, $val ) = split( /=/, $line, 2 );
+        $devices{$path}{$key} = $val;
+    }
+    if ( hex $devices{$path}{'ID_VENDOR_ID'} != hex $vid ) {
+        debug "  ID_VENDOR_ID $devices{$path}{'ID_VENDOR_ID'} != $vid\n";
+        next;
+    }
+    if ( hex $devices{$path}{'ID_MODEL_ID'} != hex $pid ) {
+        debug "  ID_MODEL_ID $devices{$path}{'ID_MODEL_ID'} != $pid\n";
+        next;
+    }
+
+    debug "  Found keyboard!\n";
+
+    if ( $devices{$path}{'ID_MM_DEVICE_IGNORE'} ) {
+        debug "  ID_MM_DEVICE_IGNORE is set - good!\n";
+    }
+
+    if ( $devices{$path}{'ID_MM_CANDIDATE'}) {
+      my $rules = "$Bin/../etc/99-kaleidoscope.rules";
+      print_warning <<EOWARN
+
+WARNING: your udev rules are currently configured to suggest
+that your keyboard is suitable for use by ModemManager.  This
+means that there is a risk of ModemManager interfering.  To avoid
+this, copy
+
+    $rules
+
+to /etc/udev/rules.d
+EOWARN
+    }
+
+    print $devices{$path}{DEVNAME};
+    exit(0);
+}
+
+print_warning(join("\n",@log));
+print_warning("ERROR: I couldn't find a USB device matching the keyboard's USB Vendor and Device IDs\n");
+

--- a/tools/find-device-port-macos
+++ b/tools/find-device-port-macos
@@ -1,0 +1,104 @@
+#!/usr/bin/env perl
+
+# Based on listArduinos.pl from https://github.com/todbot/usbSearch (License: MIT)
+# Original (C) 2012, Tod E. Kurt, http://todbot.com/blog/
+# This version by Michael Richters <gedankenexperimenter@gmail.com>
+
+use warnings;
+use strict;
+
+# ioreg might be more machine-readable than system_profiler, but I haven't been able to
+# get it to produce useful output
+my @output = qx(/usr/sbin/system_profiler SPUSBDataType);
+
+my $parse_state = 0;
+my $device      = {};
+
+LINE: foreach my $line (@output) {
+
+    chomp $line;
+
+    if ( $parse_state == 0 ) {
+        if ( $line =~ m/Model 01/ ) {
+            $parse_state = 1;
+            next LINE;
+        }
+    }
+
+    if ( $parse_state == 1 ) {
+        if ( $line =~ m/^\s*$/ ) {
+            $parse_state = 2;
+            next LINE;
+        }
+    }
+
+    if ( $parse_state == 2 ) {
+        if ( $line =~ m/Serial Number: (.+)$/ ) {
+            $device->{'serial_number'} = $1;
+            next LINE;
+        }
+        if ( $line =~ m/Location ID: (.+)$/ ) {
+            $device->{'location_id'} = $1;
+            next LINE;
+        }
+        if ( $line =~ m/Product ID: (.+)$/ ) {
+            $device->{'product_id'} = $1;
+            next LINE;
+        }
+        if ( $line =~ m/Vendor ID: (.+)$/ ) {
+            $device->{'vendor_id'} = $1;
+            next LINE;
+        }
+        if ( $line =~ m/^\s*$/ ) {
+            last LINE;
+        }
+    }
+
+}
+
+die "Can't find Model 01" if ( $device == {} );
+
+my $serial_port_name = "";
+
+if ( exists( $device->{'serial_number'} ) ) {
+    $serial_port_name = "/dev/cu.usbmodem" . $device->{'serial_number'};
+    if ( -e $serial_port_name ) {
+        print $serial_port_name;
+        exit 0;
+    }
+    # High Sierra sometimes has a mismatch between the serial number and the device
+    # filename. I'm not sure why, but system_profiler has a serial number ending in "E",
+    # whereas the device filename ends in "1". In fact, when I change HID.getShortName()
+    # to return "kbio02", the final character is replaced with a "1", so we should do the
+    # same here.
+    $serial_port_name =~ s/.$/1/;
+    if ( -e $serial_port_name ) {
+        print $serial_port_name;
+        exit 0;
+    }
+}
+
+# Here, also, the final character is always a "1", so if macOS ever stops doing that, this
+# will need an update, as well.
+if ( exists( $device->{'location_id'} ) ) {
+    my $loc = substr( $device->{'location_id'}, 2, 3 );
+    $serial_port_name = "/dev/cu.usbmodem" . $loc . 1;
+    if ( -e $serial_port_name ) {
+        print $serial_port_name;
+        exit 0;
+    }
+}
+
+# If none of the above tests succeeds, just list the directory and see if there are any
+# files that have the device shortname that we expect:
+foreach my $line (qx(ls /dev/cu.usbmodem*)) {
+    # If this script gets used for the Model 02 (or anything else that won't end it "1"),
+    # the line below should probably drop the final character (see above):
+    if ( $line =~ m/kbio01/ ) {
+	chomp $line;
+	print $line;
+	exit 0;
+    }
+}
+
+die "Can't find Model 01 serial port name";


### PR DESCRIPTION
The `kaleidoscope-builder` tool is starting to show its age, and the mistakes made during its design: it didn't have first-class support for different hardware, and it was a lot more brittle one would have liked.

The new build system is much more modular, has first-class support for different hardware, and wraps the tools used much more thinly. It's also less code, too.

This addresses keyboardio/Kaleidoscope#497 at least partially.