### PR TITLE
quality/run-astyle: Let us ignore certain files when running astyle

### DIFF
--- a/quality/run-astyle
+++ b/quality/run-astyle
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 ASTYLE_FILE_PATTERN='\(\.h\|\.cpp\|\.ino\)$'
-git ls-files |grep "$ASTYLE_FILE_PATTERN" | xargs -n 1 astyle -q --style=google --unpad-paren --pad-header --pad-oper --indent-classes --indent=spaces=2
+ASTYLE_IGNORE_PATTERN='\(^testing/googletest/\)'
+git ls-files |grep "$ASTYLE_FILE_PATTERN" | grep -v "$ASTYLE_IGNORE_PATTERN" | xargs -n 1 astyle -q --style=google --unpad-paren --pad-header --pad-oper --indent-classes --indent=spaces=2


### PR DESCRIPTION
There are parts of Kaleidoscope - imported 3rd party libraries - on which we do not want to run astyle. Filter those out from the list of files.
