### PR TITLE
makefiles: Bump TRAVIS_ARDUINO to 1.8.13

### DIFF
--- a/makefiles/rules.mk
+++ b/makefiles/rules.mk
@@ -4,7 +4,7 @@ PLUGIN_TEST_BIN_DIR ?= $(PLUGIN_TEST_SUPPORT_DIR)/../toolchain/$(shell gcc --pri
 
 KALEIDOSCOPE_BUILDER_DIR ?= $(BOARD_HARDWARE_PATH)/keyboardio/avr/libraries/Kaleidoscope/bin/
 
-TRAVIS_ARDUINO=arduino-1.8.10
+TRAVIS_ARDUINO=arduino-1.8.13
 TRAVIS_ARDUINO_FILE = $(TRAVIS_ARDUINO)-linux64.tar.xz
 TRAVIS_ARDUINO_PATH ?= $(shell pwd)/$(TRAVIS_ARDUINO)
 TRAVIS_ARDUINO_DOWNLOAD_URL = http://downloads.arduino.cc/$(TRAVIS_ARDUINO_FILE)


### PR DESCRIPTION
We have pending changes that require a newer arduino-builder (for virtual builds only), so up the version of Arduino we use in Travis to 1.8.13.