### PR TITLE
Allow function parameters to be aligned at greater indentation

### DIFF
--- a/quality/run-astyle
+++ b/quality/run-astyle
@@ -2,4 +2,4 @@
 
 ASTYLE_FILE_PATTERN='\(\.h\|\.cpp\|\.ino\)$'
 ASTYLE_IGNORE_PATTERN='\(^testing/googletest/\)'
-git ls-files |grep "$ASTYLE_FILE_PATTERN" | grep -v "$ASTYLE_IGNORE_PATTERN" | xargs -n 1 astyle -q --style=google --unpad-paren --pad-header --pad-oper --indent-classes --indent=spaces=2
+git ls-files |grep "$ASTYLE_FILE_PATTERN" | grep -v "$ASTYLE_IGNORE_PATTERN" | xargs -n 1 astyle -q --style=google --unpad-paren --pad-header --pad-oper --indent-classes --indent=spaces=2 --max-continuation-indent=80


### PR DESCRIPTION
I've been finding myself constantly distracted by and wrestling with indentation issues because of the restrictions astyle imposes. If I've got a function with a long name, and it takes multiple parameters, getting something readable has been very difficult. Here's an example:
```c++
uint32_t VirtualDeviceTest::ExpectReportAfterMillisWith(uint32_t t, Key key, std::string message) {
  sim_.RunForMillis(t);
  return ExpectReportWith(key, message);
}
```
That first line is 99 characters long; well over the limit I'd like to use for line length, and it's not the longest example. Astyle gives me a few options. I could put all the arguments together on a separate line, but then the indentation rule lines them up exactly with the following code, which I find confusing; it's hard to see where the function's code block begins:
```c++
uint32_t VirtualDeviceTest::ExpectReportAfterMillisWith(
  uint32_t t, Key key, std::string message) {
  sim_.RunForMillis(t);
  return ExpectReportWith(key, message);
}
```
Alternatively, I could keep the first parameter on the line above:
```c++
uint32_t VirtualDeviceTest::ExpectReportAfterMillisWith(uint32_t t,
    Key key, std::string message) {
  sim_.RunForMillis(t);
  return ExpectReportWith(key, message);
}
```
Now I'm getting some visual distinction between function parameters and function body, but it's hard to see the three parameters all together, and their order is particularly difficult, because left-to-right is disturbed.

Here's what I want it to look like:
```c++
uint32_t VirtualDeviceTest::ExpectReportAfterMillisWith(uint32_t t,
                                                        Key key,
                                                        std::string message) {
  sim_.RunForMillis(t);
  return ExpectReportWith(key, message);
}
```
I find this clear, with very obvious separation of parameters and function body, and the parameters are all lined up and in an unconfusing order. Indeed, our current astyle settings allow this, but not if the indentation of the second and third lines would be more than 40 characters. As it is, astyle turns the above into this:
```c++
uint32_t VirtualDeviceTest::ExpectReportAfterMillisWith(uint32_t t,
    Key key,
    std::string message) {
  sim_.RunForMillis(t);
  return ExpectReportWith(key, message);
}
```
By increasing the limit to 80 (I'm suggesting that because I feel like lines longer than that should be discouraged in general), function declarations in the style I prefer are possible, and I can stop agonizing over which of the bad choices astyle gives me I'm going to compromise on.

This would change a few lines in 8 existing files of Kaleidoscope code. I'll submit that as a separate PR.